### PR TITLE
Fixed Sketchybar Wifi Network Name

### DIFF
--- a/.config/sketchybar/plugins/wifi.sh
+++ b/.config/sketchybar/plugins/wifi.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env sh
 
-LABEL="$(networksetup -listallhardwareports | awk '/Wi-Fi/{getline; print $2}' | xargs networksetup -getairportnetwork | sed "s/Current Wi-Fi Network: //")"
+LABEL="$(networksetup -listallhardwareports | awk '/Wi-Fi/{getline; print $2}' | xargs networksetup -getairportnetwork)"
 
-if [[ "$LABEL" -eq "YOU" ]]; then
-   sketchybar --set $NAME label=$LABEL
-else
-   sketchybar --set $NAME label="Disconnected"
+if [[ "$LABEL" == *"You are not associated with an AirPort network."* ]]; then
+   sketchybar --set wifi label="Disconnected"
+else   LABEL=$(echo "$LABEL" | sed "s/Current Wi-Fi Network: //")
+   sketchybar --set wifi label="$LABEL"
 fi
-


### PR DESCRIPTION
The Wifi Plugin was showing "Disconnected" even though I was connected to my network

And when fixed to show the network, only the first "word" of the network was showing, this make default to differentiate between my 5hz and 2.4hz networks.

These changes fix both issues.